### PR TITLE
Changed footer link as the website was invalid

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -21,7 +21,7 @@ export const Footer = ({ docs }) => {
             <span className="opacity-60">A product by </span>{" "}
             <Link
               className="blue-link"
-              href="https://hextastudio.vercel.app"
+              href="https://hextastudio.in"
               target="_blank"
             >
               HextaStudio


### PR DESCRIPTION
Your website link is invalid `https://hextastudio.vercel.app/` so I changed it to `https://hextastudio.in` since it's the right one.